### PR TITLE
Fix stylization of 'WildFly' especially in publicly visible strings.

### DIFF
--- a/src/main/java/org/wildfly/bot/LifecycleProcessor.java
+++ b/src/main/java/org/wildfly/bot/LifecycleProcessor.java
@@ -29,7 +29,7 @@ import java.util.stream.Collectors;
 @ApplicationScoped
 public class LifecycleProcessor {
 
-    public static final String EMAIL_SUBJECT = "Unsuccessful installation of Wildfly Bot Application";
+    public static final String EMAIL_SUBJECT = "Unsuccessful installation of WildFly Bot Application";
     public static final String EMAIL_TEXT = """
             Hello,
 

--- a/src/main/java/org/wildfly/bot/model/RuntimeConstants.java
+++ b/src/main/java/org/wildfly/bot/model/RuntimeConstants.java
@@ -22,7 +22,7 @@ public class RuntimeConstants {
 
     public static final String BOT_REPO_REF_FOOTER = "More information about the [%s](https://github.com/wildfly/wildfly-github-bot)";
 
-    public static final String BOT_JIRA_LINKS_HEADER = "Wildfly issue links:\n";
+    public static final String BOT_JIRA_LINKS_HEADER = "WildFly issue links:\n";
 
     public static final String BOT_JIRA_LINK_TEMPLATE = "https://issues.redhat.com/browse/%1$s";
 

--- a/src/test/java/org/wildfly/bot/webhooks/PRCommitCheckTest.java
+++ b/src/test/java/org/wildfly/bot/webhooks/PRCommitCheckTest.java
@@ -20,7 +20,7 @@ import static org.wildfly.bot.model.RuntimeConstants.DEFAULT_COMMIT_MESSAGE;
 import static org.wildfly.bot.model.RuntimeConstants.PROJECT_PATTERN_REGEX;
 
 /**
- * Tests for the Wildfly -> Format -> Commit checks.
+ * Tests for the WildFly -> Format -> Commit checks.
  */
 @QuarkusTest
 @GitHubAppTest

--- a/src/test/java/org/wildfly/bot/webhooks/PRDescriptionCheckTest.java
+++ b/src/test/java/org/wildfly/bot/webhooks/PRDescriptionCheckTest.java
@@ -20,7 +20,7 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.never;
 
 /**
- * Tests for the Wildfly -> Format -> Description checks.
+ * Tests for the WildFly -> Format -> Description checks.
  */
 @QuarkusTest
 @GitHubAppTest

--- a/src/test/java/org/wildfly/bot/webhooks/PRFormatOverrideProjectKeyTest.java
+++ b/src/test/java/org/wildfly/bot/webhooks/PRFormatOverrideProjectKeyTest.java
@@ -16,7 +16,7 @@ import static org.wildfly.bot.model.RuntimeConstants.DEFAULT_TITLE_MESSAGE;
 import static org.wildfly.bot.model.RuntimeConstants.PROJECT_PATTERN_REGEX;
 
 /**
- * Tests for the Wildfly -> ProjectKey function.
+ * Tests for the WildFly -> ProjectKey function.
  */
 @QuarkusTest
 @GitHubAppTest

--- a/src/test/java/org/wildfly/bot/webhooks/PRRuleDescriptionCheckTest.java
+++ b/src/test/java/org/wildfly/bot/webhooks/PRRuleDescriptionCheckTest.java
@@ -13,7 +13,7 @@ import org.wildfly.bot.utils.testing.PullRequestJson;
 import org.wildfly.bot.utils.testing.internal.TestModel;
 
 /**
- * Tests for the Wildfly -> Rules -> Body checks.
+ * Tests for the WildFly -> Rules -> Body checks.
  */
 @QuarkusTest
 @GitHubAppTest

--- a/src/test/java/org/wildfly/bot/webhooks/PRRuleDirectoryHitTest.java
+++ b/src/test/java/org/wildfly/bot/webhooks/PRRuleDirectoryHitTest.java
@@ -23,7 +23,7 @@ import org.wildfly.bot.utils.testing.internal.TestModel;
 import java.util.List;
 
 /**
- * Tests for the Wildfly -> Rules -> Directories checks.
+ * Tests for the WildFly -> Rules -> Directories checks.
  */
 @QuarkusTest
 @GitHubAppTest

--- a/src/test/java/org/wildfly/bot/webhooks/PRRuleNotifyTest.java
+++ b/src/test/java/org/wildfly/bot/webhooks/PRRuleNotifyTest.java
@@ -13,7 +13,7 @@ import org.wildfly.bot.utils.testing.PullRequestJson;
 import org.wildfly.bot.utils.testing.internal.TestModel;
 
 /**
- * Tests for the Wildfly -> Rules -> Notify function.
+ * Tests for the WildFly -> Rules -> Notify function.
  */
 @QuarkusTest
 @GitHubAppTest

--- a/src/test/java/org/wildfly/bot/webhooks/PRRuleTitleBodyCheckTest.java
+++ b/src/test/java/org/wildfly/bot/webhooks/PRRuleTitleBodyCheckTest.java
@@ -14,7 +14,7 @@ import org.wildfly.bot.utils.testing.PullRequestJson;
 import org.wildfly.bot.utils.testing.internal.TestModel;
 
 /**
- * Tests for the Wildfly -> Rules -> TitleBody checks.
+ * Tests for the WildFly -> Rules -> TitleBody checks.
  */
 @QuarkusTest
 @GitHubAppTest

--- a/src/test/java/org/wildfly/bot/webhooks/PRRuleTitleCheckTest.java
+++ b/src/test/java/org/wildfly/bot/webhooks/PRRuleTitleCheckTest.java
@@ -13,7 +13,7 @@ import org.wildfly.bot.utils.testing.PullRequestJson;
 import org.wildfly.bot.utils.testing.internal.TestModel;
 
 /**
- * Tests for the Wildfly -> Rules -> Title checks.
+ * Tests for the WildFly -> Rules -> Title checks.
  */
 @QuarkusTest
 @GitHubAppTest

--- a/src/test/java/org/wildfly/bot/webhooks/PRTitleCheckTest.java
+++ b/src/test/java/org/wildfly/bot/webhooks/PRTitleCheckTest.java
@@ -25,7 +25,7 @@ import static org.wildfly.bot.model.RuntimeConstants.DEFAULT_TITLE_MESSAGE;
 import static org.wildfly.bot.model.RuntimeConstants.PROJECT_PATTERN_REGEX;
 
 /**
- * Tests for the Wildfly -> Format -> Title checks.
+ * Tests for the WildFly -> Format -> Title checks.
  */
 @QuarkusTest
 @GitHubAppTest


### PR DESCRIPTION
The change in `src/main/java/org/wildfly/bot/model/RuntimeConstants.java` is the crux of the issue.