### PR TITLE
Added more meaningful error message when config file not found in repository

### DIFF
--- a/src/main/java/org/wildfly/bot/LifecycleProcessor.java
+++ b/src/main/java/org/wildfly/bot/LifecycleProcessor.java
@@ -72,7 +72,12 @@ public class LifecycleProcessor {
                 for (GHRepository repository : app.getInstallation().listRepositories()) {
                     try {
                         WildFlyConfigFile wildflyBotConfigFile = fileProvider.fetchConfigFile(repository,
-                                RuntimeConstants.CONFIG_FILE_NAME, ConfigFile.Source.DEFAULT, WildFlyConfigFile.class).get();
+                                RuntimeConstants.CONFIG_FILE_NAME, ConfigFile.Source.DEFAULT, WildFlyConfigFile.class)
+                                .orElseThrow(
+                                        () -> new IllegalStateException(
+                                                "Unable to read file %s for repository %s. Either the file does not exist or the 'Contents' permission has not been set for the application."
+                                                        .formatted(".github/" + RuntimeConstants.CONFIG_FILE_NAME,
+                                                                repository.getFullName())));
                         List<String> emailAddresses = wildflyBotConfigFile.wildfly.emails;
                         List<String> problems = configFileChangeProcessor.validateFile(wildflyBotConfigFile, repository);
 


### PR DESCRIPTION
/cc @xjusko 
With test included.
Given how trivial this was, I didn't bother creating a GH issue for it.

Previous behavior:
```
2025-02-19 13:48:52,794 ERROR [io.qua.run.Application] (Quarkus Main Thread) Failed to start application (with profile [dev]): java.lang.RuntimeException: Failed to start quarkus
        at io.quarkus.runner.ApplicationImpl.doStart(Unknown Source)
        at io.quarkus.runtime.Application.start(Application.java:101)
        at io.quarkus.runtime.ApplicationLifecycleManager.run(ApplicationLifecycleManager.java:111)
        at io.quarkus.runtime.Quarkus.run(Quarkus.java:71)
        at io.quarkus.runtime.Quarkus.run(Quarkus.java:44)
        at io.quarkus.runtime.Quarkus.run(Quarkus.java:124)
        at io.quarkus.runner.GeneratedMain.main(Unknown Source)
        at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
        at java.base/java.lang.reflect.Method.invoke(Method.java:580)
        at io.quarkus.runner.bootstrap.StartupActionImpl$1.run(StartupActionImpl.java:113)
        at java.base/java.lang.Thread.run(Thread.java:1583)
Caused by: java.util.NoSuchElementException: No value present
        at java.base/java.util.Optional.get(Optional.java:143)
        at org.wildfly.bot.LifecycleProcessor.onStart(LifecycleProcessor.java:75)
        at org.wildfly.bot.LifecycleProcessor_Observer_onStart_TvxD8j1qVR6DUOvEgAlAA5-yYNI.notify(Unknown Source)
        at io.quarkus.arc.impl.EventImpl$Notifier.notifyObservers(EventImpl.java:351)
        at io.quarkus.arc.impl.EventImpl$Notifier.notify(EventImpl.java:333)
        at io.quarkus.arc.impl.EventImpl.fire(EventImpl.java:80)
        at io.quarkus.arc.runtime.ArcRecorder.fireLifecycleEvent(ArcRecorder.java:155)
        at io.quarkus.arc.runtime.ArcRecorder.handleLifecycleEvents(ArcRecorder.java:106)
        at io.quarkus.deployment.steps.LifecycleEventsBuildStep$startupEvent1144526294.deploy_0(Unknown Source)
        at io.quarkus.deployment.steps.LifecycleEventsBuildStep$startupEvent1144526294.deploy(Unknown Source)
        ... 11 more
```
Newer behavior:
```
2025-02-24 15:10:51,634 ERROR [org.wil.bot.LifecycleProcessor] (Quarkus Main Thread) Unable to retrieve or parse the configuration file from the repository mskacelik/wildfly-github-bot-playground: java.lang.IllegalStateException: Unable to read file .github/wildfly-bot.yml for repository mskacelik/wildfly-github-bot-playground. Either the file does not exist or the 'Contents' permission has not been set for the application.
        at org.wildfly.bot.LifecycleProcessor.lambda$onStart$0(LifecycleProcessor.java:79)
        at java.base/java.util.Optional.orElseThrow(Optional.java:403)
        at org.wildfly.bot.LifecycleProcessor.onStart(LifecycleProcessor.java:76)
        at org.wildfly.bot.LifecycleProcessor_Observer_onStart_TvxD8j1qVR6DUOvEgAlAA5-yYNI.notify(Unknown Source)
        at io.quarkus.arc.impl.EventImpl$Notifier.notifyObservers(EventImpl.java:351)
        at io.quarkus.arc.impl.EventImpl$Notifier.notify(EventImpl.java:333)
        at io.quarkus.arc.impl.EventImpl.fire(EventImpl.java:80)
        at io.quarkus.arc.runtime.ArcRecorder.fireLifecycleEvent(ArcRecorder.java:155)
        at io.quarkus.arc.runtime.ArcRecorder.handleLifecycleEvents(ArcRecorder.java:106)
        at io.quarkus.deployment.steps.LifecycleEventsBuildStep$startupEvent1144526294.deploy_0(Unknown Source)
        at io.quarkus.deployment.steps.LifecycleEventsBuildStep$startupEvent1144526294.deploy(Unknown Source)
        at io.quarkus.runner.ApplicationImpl.doStart(Unknown Source)
        at io.quarkus.runtime.Application.start(Application.java:101)
        at io.quarkus.runtime.ApplicationLifecycleManager.run(ApplicationLifecycleManager.java:111)
        at io.quarkus.runtime.Quarkus.run(Quarkus.java:71)
        at io.quarkus.runtime.Quarkus.run(Quarkus.java:44)
        at io.quarkus.runtime.Quarkus.run(Quarkus.java:124)
        at io.quarkus.runner.GeneratedMain.main(Unknown Source)
        at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
        at java.base/java.lang.reflect.Method.invoke(Method.java:580)
        at io.quarkus.runner.bootstrap.StartupActionImpl$1.run(StartupActionImpl.java:113)
        at java.base/java.lang.Thread.run(Thread.java:1583)
```