### PR TITLE
Added rule (id) for each user mention

### DIFF
--- a/src/test/java/org/wildfly/bot/webhooks/PRChecksTest.java
+++ b/src/test/java/org/wildfly/bot/webhooks/PRChecksTest.java
@@ -81,7 +81,7 @@ public class PRChecksTest {
                     GHRepository repo = mocks.repository(TestConstants.TEST_REPO);
                     WildflyGitHubBotTesting.verifyFormatSuccess(repo, pullRequestJson);
                     GHPullRequest mockedPR = mocks.pullRequest(pullRequestJson.id());
-                    Mockito.verify(mockedPR).comment("/cc @Butterfly, @Tadpole");
+                    Mockito.verify(mockedPR).comment("/cc @Tadpole [Title], @Butterfly [Description]");
                 });
     }
 
@@ -116,7 +116,7 @@ public class PRChecksTest {
                     GHRepository repo = mocks.repository(TestConstants.TEST_REPO);
                     WildflyGitHubBotTesting.verifyFormatFailure(repo, pullRequestJson, "commit, description, title");
                     GHPullRequest mockedPR = mocks.pullRequest(pullRequestJson.id());
-                    Mockito.verify(mockedPR, Mockito.never()).comment("/cc @Butterfly, @Tadpole");
+                    Mockito.verify(mockedPR, Mockito.never()).comment("/cc @Tadpole [Title], @Butterfly [Description]");
                 });
     }
 }

--- a/src/test/java/org/wildfly/bot/webhooks/PRMentionsReviewsCombinationTest.java
+++ b/src/test/java/org/wildfly/bot/webhooks/PRMentionsReviewsCombinationTest.java
@@ -97,7 +97,7 @@ public class PRMentionsReviewsCombinationTest {
                 mocks -> WildflyGitHubBotTesting.mockRepo(mocks, wildflyConfigFile, pullRequestJson, mockedContext))
                 .pullRequestEvent(pullRequestJson)
                 .then(mocks -> {
-                    Mockito.verify(mocks.pullRequest(pullRequestJson.id())).comment("/cc @Butterfly, @Tadpole");
+                    Mockito.verify(mocks.pullRequest(pullRequestJson.id())).comment("/cc @Tadpole [test], @Butterfly [test]");
                     Mockito.verify(mocks.pullRequest(pullRequestJson.id()), Mockito.never())
                             .requestReviewers(ArgumentMatchers.anyList());
                 });
@@ -213,7 +213,7 @@ public class PRMentionsReviewsCombinationTest {
                 mocks -> WildflyGitHubBotTesting.mockRepo(mocks, wildflyConfigFile, pullRequestJson, mockedContext))
                 .pullRequestEvent(pullRequestJson)
                 .then(mocks -> {
-                    Mockito.verify(mocks.pullRequest(pullRequestJson.id())).comment("/cc @Duke");
+                    Mockito.verify(mocks.pullRequest(pullRequestJson.id())).comment("/cc @Duke [test2]");
                     ArgumentCaptor<List<GHUser>> captor = ArgumentCaptor.forClass(List.class);
                     Mockito.verify(mocks.pullRequest(pullRequestJson.id()), Mockito.times(2))
                             .requestReviewers(captor.capture());

--- a/src/test/java/org/wildfly/bot/webhooks/PRNotifyChangeOnPREditTest.java
+++ b/src/test/java/org/wildfly/bot/webhooks/PRNotifyChangeOnPREditTest.java
@@ -93,7 +93,7 @@ public class PRNotifyChangeOnPREditTest {
                       notify: [Butterfly, Duke]""";
 
         mockedContext = MockedGHPullRequest.builder(pullRequestJson.id())
-                .comment("/cc @Duke", wildFlyBotConfig.githubName())
+                .comment("/cc @Duke [WFLY]", wildFlyBotConfig.githubName())
                 .commit("WFLY-123 commit")
                 .files("src/pom.xml", "app/pom.xml")
                 .reviewers("Tadpole")
@@ -139,7 +139,7 @@ public class PRNotifyChangeOnPREditTest {
                 mocks -> WildflyGitHubBotTesting.mockRepo(mocks, wildflyConfigFile, pullRequestJson, mockedContext))
                 .pullRequestEvent(pullRequestJson)
                 .then(mocks -> {
-                    Mockito.verify(mocks.pullRequest(pullRequestJson.id())).comment("/cc @Duke");
+                    Mockito.verify(mocks.pullRequest(pullRequestJson.id())).comment("/cc @Duke [test2]");
                     ArgumentCaptor<List<GHUser>> captor = ArgumentCaptor.forClass(List.class);
                     Mockito.verify(mocks.pullRequest(pullRequestJson.id())).requestReviewers(captor.capture());
                     Assertions.assertEquals(captor.getValue().size(), 1);
@@ -162,14 +162,14 @@ public class PRNotifyChangeOnPREditTest {
                       notify: [Tadpole]""";
 
         mockedContext = MockedGHPullRequest.builder(pullRequestJson.id())
-                .comment("/cc @Tadpole", wildFlyBotConfig.githubName())
+                .comment("/cc @Tadpole [previous rule]", wildFlyBotConfig.githubName())
                 .commit("WFLY-123 commit");
 
         TestModel.given(
                 mocks -> WildflyGitHubBotTesting.mockRepo(mocks, wildflyConfigFile, pullRequestJson, mockedContext))
                 .pullRequestEvent(pullRequestJson)
                 .then(mocks -> {
-                    Mockito.verify(mocks.issueComment(0L)).update("/cc @Tadpole, @Butterfly");
+                    Mockito.verify(mocks.issueComment(0L)).update("/cc @Tadpole [previous rule], @Butterfly [new rule]");
                     Mockito.verify(mocks.pullRequest(pullRequestJson.id()), Mockito.never()).requestReviewers(anyList());
                 });
     }
@@ -198,7 +198,7 @@ public class PRNotifyChangeOnPREditTest {
                 mocks -> WildflyGitHubBotTesting.mockRepo(mocks, wildflyConfigFile, pullRequestJson, mockedContext))
                 .pullRequestEvent(pullRequestJson)
                 .then(mocks -> {
-                    Mockito.verify(mocks.pullRequest(pullRequestJson.id())).comment("/cc @Duke");
+                    Mockito.verify(mocks.pullRequest(pullRequestJson.id())).comment("/cc @Duke [test2]");
                     Mockito.verify(mocks.pullRequest(pullRequestJson.id()), Mockito.never()).requestReviewers(anyList());
                 });
     }

--- a/src/test/java/org/wildfly/bot/webhooks/PRRuleDescriptionCheckTest.java
+++ b/src/test/java/org/wildfly/bot/webhooks/PRRuleDescriptionCheckTest.java
@@ -42,7 +42,7 @@ public class PRRuleDescriptionCheckTest {
                 .pullRequestEvent(pullRequestJson)
                 .then(mocks -> {
                     GHPullRequest mockedPR = mocks.pullRequest(pullRequestJson.id());
-                    Mockito.verify(mockedPR).comment("/cc @Tadpole");
+                    Mockito.verify(mockedPR).comment("/cc @Tadpole [Description]");
                     GHRepository repo = mocks.repository(TestConstants.TEST_REPO);
                     WildflyGitHubBotTesting.verifyFormatSuccess(repo, pullRequestJson);
                 });
@@ -64,7 +64,7 @@ public class PRRuleDescriptionCheckTest {
                 .pullRequestEvent(pullRequestJson)
                 .then(mocks -> {
                     GHPullRequest mockedPR = mocks.pullRequest(pullRequestJson.id());
-                    Mockito.verify(mockedPR, Mockito.never()).comment("/cc @Tadpole");
+                    Mockito.verify(mockedPR, Mockito.never()).comment("/cc @Tadpole [Description]");
                     GHRepository repo = mocks.repository(TestConstants.TEST_REPO);
                     WildflyGitHubBotTesting.verifyFormatSuccess(repo, pullRequestJson);
                 });
@@ -85,7 +85,7 @@ public class PRRuleDescriptionCheckTest {
                 .pullRequestEvent(pullRequestJson)
                 .then(mocks -> {
                     GHPullRequest mockedPR = mocks.pullRequest(pullRequestJson.id());
-                    Mockito.verify(mockedPR).comment("/cc @Tadpole");
+                    Mockito.verify(mockedPR).comment("/cc @Tadpole [Description]");
                     GHRepository repo = mocks.repository(TestConstants.TEST_REPO);
                     WildflyGitHubBotTesting.verifyFormatSuccess(repo, pullRequestJson);
                 });

--- a/src/test/java/org/wildfly/bot/webhooks/PRRuleDirectoryHitTest.java
+++ b/src/test/java/org/wildfly/bot/webhooks/PRRuleDirectoryHitTest.java
@@ -186,7 +186,7 @@ public class PRRuleDirectoryHitTest {
                     GHPullRequest mockedPR = mocks.pullRequest(pullRequestJson.id());
                     Mockito.verify(mockedPR, Mockito.times(2)).listFiles();
                     Mockito.verify(mockedPR, Mockito.times(2)).listComments();
-                    Mockito.verify(mockedPR, Mockito.never()).comment("/cc @Tadpole");
+                    Mockito.verify(mockedPR, Mockito.never()).comment("/cc @Tadpole [Directory Test]");
                 });
     }
 }

--- a/src/test/java/org/wildfly/bot/webhooks/PRRuleNotifyTest.java
+++ b/src/test/java/org/wildfly/bot/webhooks/PRRuleNotifyTest.java
@@ -44,7 +44,7 @@ public class PRRuleNotifyTest {
                 .pullRequestEvent(pullRequestJson)
                 .then(mocks -> {
                     GHPullRequest mockedPR = mocks.pullRequest(pullRequestJson.id());
-                    Mockito.verify(mockedPR).comment("/cc @Tadpole, @Duke");
+                    Mockito.verify(mockedPR).comment("/cc @Tadpole [Title], @Duke [Title]");
                     GHRepository repo = mocks.repository(TestConstants.TEST_REPO);
                     WildflyGitHubBotTesting.verifyFormatSuccess(repo, pullRequestJson);
                 });
@@ -67,7 +67,7 @@ public class PRRuleNotifyTest {
                 .pullRequestEvent(pullRequestJson)
                 .then(mocks -> {
                     GHPullRequest mockedPR = mocks.pullRequest(pullRequestJson.id());
-                    Mockito.verify(mockedPR).comment("/cc @Butterfly, @Doggo, @Tadpole, @Duke");
+                    Mockito.verify(mockedPR).comment("/cc @Tadpole [WFLY], @Duke [WFLY], @Butterfly [Title], @Doggo [Title]");
                     GHRepository repo = mocks.repository(TestConstants.TEST_REPO);
                     WildflyGitHubBotTesting.verifyFormatSuccess(repo, pullRequestJson);
                 });
@@ -90,7 +90,7 @@ public class PRRuleNotifyTest {
                 .pullRequestEvent(pullRequestJson)
                 .then(mocks -> {
                     GHPullRequest mockedPR = mocks.pullRequest(pullRequestJson.id());
-                    Mockito.verify(mockedPR).comment("/cc @Doggo, @Tadpole, @Duke");
+                    Mockito.verify(mockedPR).comment("/cc @Tadpole [Title, Description], @Duke [Title], @Doggo [Description]");
                     GHRepository repo = mocks.repository(TestConstants.TEST_REPO);
                     WildflyGitHubBotTesting.verifyFormatSuccess(repo, pullRequestJson);
                 });

--- a/src/test/java/org/wildfly/bot/webhooks/PRRuleTitleBodyCheckTest.java
+++ b/src/test/java/org/wildfly/bot/webhooks/PRRuleTitleBodyCheckTest.java
@@ -45,7 +45,7 @@ public class PRRuleTitleBodyCheckTest {
                 .pullRequestEvent(pullRequestJson)
                 .then(mocks -> {
                     GHPullRequest mockedPR = mocks.pullRequest(pullRequestJson.id());
-                    Mockito.verify(mockedPR).comment("/cc @Tadpole");
+                    Mockito.verify(mockedPR).comment("/cc @Tadpole [TitleBody]");
                     GHRepository repo = mocks.repository(TestConstants.TEST_REPO);
                     WildflyGitHubBotTesting.verifyFormatSuccess(repo, pullRequestJson);
                 });
@@ -68,7 +68,7 @@ public class PRRuleTitleBodyCheckTest {
                 .pullRequestEvent(pullRequestJson)
                 .then(mocks -> {
                     GHPullRequest mockedPR = mocks.pullRequest(pullRequestJson.id());
-                    Mockito.verify(mockedPR).comment("/cc @Tadpole");
+                    Mockito.verify(mockedPR).comment("/cc @Tadpole [TitleBody]");
                     GHRepository repo = mocks.repository(TestConstants.TEST_REPO);
                     WildflyGitHubBotTesting.verifyFormatSuccess(repo, pullRequestJson);
                 });
@@ -91,7 +91,7 @@ public class PRRuleTitleBodyCheckTest {
                 .pullRequestEvent(pullRequestJson)
                 .then(mocks -> {
                     GHPullRequest mockedPR = mocks.pullRequest(pullRequestJson.id());
-                    Mockito.verify(mockedPR).comment("/cc @Tadpole");
+                    Mockito.verify(mockedPR).comment("/cc @Tadpole [TitleBody]");
                     GHRepository repo = mocks.repository(TestConstants.TEST_REPO);
                     WildflyGitHubBotTesting.verifyFormatSuccess(repo, pullRequestJson);
                 });
@@ -116,7 +116,7 @@ public class PRRuleTitleBodyCheckTest {
                 .pullRequestEvent(pullRequestJson)
                 .then(mocks -> {
                     GHPullRequest mockedPR = mocks.pullRequest(pullRequestJson.id());
-                    Mockito.verify(mockedPR, Mockito.never()).comment("/cc @Tadpole");
+                    Mockito.verify(mockedPR, Mockito.never()).comment("/cc @Tadpole [TitleBody]");
                     GHRepository repo = mocks.repository(TestConstants.TEST_REPO);
                     WildflyGitHubBotTesting.verifyFormatFailure(repo, pullRequestJson, "title");
                 });

--- a/src/test/java/org/wildfly/bot/webhooks/PRRuleTitleCheckTest.java
+++ b/src/test/java/org/wildfly/bot/webhooks/PRRuleTitleCheckTest.java
@@ -41,7 +41,7 @@ public class PRRuleTitleCheckTest {
                 .pullRequestEvent(pullRequestJson)
                 .then(mocks -> {
                     GHPullRequest mockedPR = mocks.pullRequest(pullRequestJson.id());
-                    Mockito.verify(mockedPR).comment("/cc @Tadpole");
+                    Mockito.verify(mockedPR).comment("/cc @Tadpole [Title]");
                     GHRepository repo = mocks.repository(TestConstants.TEST_REPO);
                     WildflyGitHubBotTesting.verifyFormatSuccess(repo, pullRequestJson);
                 });
@@ -61,7 +61,7 @@ public class PRRuleTitleCheckTest {
                 .pullRequestEvent(pullRequestJson)
                 .then(mocks -> {
                     GHPullRequest mockedPR = mocks.pullRequest(pullRequestJson.id());
-                    Mockito.verify(mockedPR, Mockito.never()).comment("/cc @Tadpole");
+                    Mockito.verify(mockedPR, Mockito.never()).comment("/cc @Tadpole [Title]");
                     GHRepository repo = mocks.repository(TestConstants.TEST_REPO);
                     WildflyGitHubBotTesting.verifyFormatSuccess(repo, pullRequestJson);
                 });
@@ -81,7 +81,7 @@ public class PRRuleTitleCheckTest {
                 .pullRequestEvent(pullRequestJson)
                 .then(mocks -> {
                     GHPullRequest mockedPR = mocks.pullRequest(pullRequestJson.id());
-                    Mockito.verify(mockedPR).comment("/cc @Tadpole");
+                    Mockito.verify(mockedPR).comment("/cc @Tadpole [Title]");
                     GHRepository repo = mocks.repository(TestConstants.TEST_REPO);
                     WildflyGitHubBotTesting.verifyFormatSuccess(repo, pullRequestJson);
                 });


### PR DESCRIPTION
/cc @xjusko
Closes #173

Had to change more code than anticipated.

Key changes:
- Rules (as their IDs) are mentioned for each user: /cc `@user1 [rule-id-1, rule-id-2], @user2 [rule-id-2]`
- There might be issues with splitting since IDs allow `@,]` characters. Consider adding regex validation for IDs (?).
- Rules without IDs will be filtered out from the mentions.
  - This was surprising as I thought the ID field in rules was mandatory (but some tests seem to need it).
- Changed the order of some mentions in the tests because we previously used a `HashSet` for users. Now, it sequentially processes the rules and their notifies, which is more deterministic from the user's POV.
- If a previous mention comment contains users (and their rules), the newer users will be mentioned at the end of the comment, and the previous users will be replaced at their position to preserve the order of already mentioned people and append new people.
- Didn't add any new tests only changed already existing ones.

Gonna probably do more of stress testing locally.