### PR TITLE
Disable application lifecycle observers in tests

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -41,6 +41,8 @@ G/UUwySoo+AQ+rd2EPhyexjqXBhRGe+EDGFVFivaQzTT8/5bt/VddbTcw2IpmXYj\
 LW6V8BbcP5MRhd2JQSRh16nWwSQJ2BdpUZFwayEEQ6UcrMfqvA0=\
 -----END RSA PRIVATE KEY-----
 
+# disables observer event when the test is executed
+quarkus.arc.test.disable-application-lifecycle-observers=true
 %dev.wildfly-bot.dry-run=true
 %test.wildfly-bot.mergable-status-update.timeout=1
 


### PR DESCRIPTION
/cc @xjusko 
Closes #215 

The problem was that the `onStart` method (observer) was executed at the start of the test, so there was no time for the data mocking (setup) -> logs.

After the data was mocked `startupEvent.fire(new StartupEvent())` fired the event starting the observer method, that was the reason why the tests still passed.

The issue was fixed by adding a special Quarkus property for disabling lifecycle observing during testing, this could potentially be problem in a future if we going to tests some initialization events. 