### PR TITLE
Add check for newly opened dependabot PR and skip format check on that PR.

### DIFF
--- a/src/main/java/org/wildfly/bot/PullRequestFormatProcessor.java
+++ b/src/main/java/org/wildfly/bot/PullRequestFormatProcessor.java
@@ -98,6 +98,12 @@ public class PullRequestFormatProcessor {
             return;
         }
 
+        if (pullRequest.getUser().getLogin().equals(DEPENDABOT)
+                && pullRequestPayload.getAction().equals(PullRequest.Opened.NAME)) {
+            LOG.info("Skipping format check on newly opened dependabot PRs.");
+            return;
+        }
+
         if (!wildflyConfigFile.wildfly.format.enabled) {
             LOG.info("Skipping format due to format being disabled");
             return;

--- a/src/test/java/org/wildfly/bot/webhooks/PRDependabotTest.java
+++ b/src/test/java/org/wildfly/bot/webhooks/PRDependabotTest.java
@@ -1,7 +1,10 @@
 package org.wildfly.bot.webhooks;
 
 import io.quarkiverse.githubapp.testing.GitHubAppTest;
+import io.quarkus.test.InMemoryLogHandler;
 import io.quarkus.test.junit.QuarkusTest;
+import org.jboss.logmanager.Level;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.kohsuke.github.GHPullRequest;
@@ -10,8 +13,11 @@ import org.mockito.Mockito;
 import org.wildfly.bot.model.RuntimeConstants;
 import org.wildfly.bot.utils.TestConstants;
 import org.wildfly.bot.utils.WildflyGitHubBotTesting;
+import org.wildfly.bot.utils.model.Action;
 import org.wildfly.bot.utils.testing.PullRequestJson;
 import org.wildfly.bot.utils.testing.internal.TestModel;
+
+import java.util.logging.LogManager;
 
 import static org.wildfly.bot.model.RuntimeConstants.PROJECT_PATTERN_REGEX;
 
@@ -22,6 +28,14 @@ import static org.wildfly.bot.model.RuntimeConstants.PROJECT_PATTERN_REGEX;
 @GitHubAppTest
 public class PRDependabotTest {
 
+    private static final java.util.logging.Logger rootLogger = LogManager.getLogManager().getLogger("org.wildfly.bot");
+    private static final InMemoryLogHandler inMemoryLogHandler = new InMemoryLogHandler(
+            record -> record.getLevel().intValue() >= Level.ALL.intValue());
+
+    static {
+        rootLogger.addHandler(inMemoryLogHandler);
+    }
+
     private String wildflyConfigFile;
     private PullRequestJson pullRequestJson;
 
@@ -31,30 +45,29 @@ public class PRDependabotTest {
     }
 
     @Test
-    void testDependabotPR() throws Throwable {
+    void testDependabotOnPREdited() throws Throwable {
         wildflyConfigFile = """
                 wildfly:
                       format:
                         description:
                           regexes:
                             - pattern: "https://issues.redhat.com/browse/WFLY-\\\\d+"
+                              message: "The PR description must contain a link to the JIRA issue"
                 """;
 
         pullRequestJson = TestModel.setPullRequestJsonBuilder(pullRequestJsonBuilder -> pullRequestJsonBuilder
                 .userLogin(RuntimeConstants.DEPENDABOT)
                 .title("Bump some version from x.y to x.y+1")
-                .description("Very detailed description of this upgrade."));
+                .description("Very detailed description of this upgrade.")
+                .action(Action.EDITED));
 
         TestModel.given(mocks -> WildflyGitHubBotTesting.mockRepo(mocks, wildflyConfigFile, pullRequestJson))
                 .pullRequestEvent(pullRequestJson)
                 .then(mocks -> {
-                    GHPullRequest mockedPR = mocks.pullRequest(pullRequestJson.id());
-                    Mockito.verify(mockedPR).comment("WildFly Bot recognized this PR as dependabot dependency update. " +
-                            "Please create a WFLY issue and add new comment containing this JIRA link please.");
                     GHRepository repo = mocks.repository(TestConstants.TEST_REPO);
                     WildflyGitHubBotTesting.verifyFormatFailure(repo, pullRequestJson, "description, title");
                     WildflyGitHubBotTesting.verifyFailedFormatComment(mocks, pullRequestJson, String.format("""
-                            - Invalid description content
+                            - The PR description must contain a link to the JIRA issue
 
                             - %s""", String.format(RuntimeConstants.DEFAULT_TITLE_MESSAGE,
                             PROJECT_PATTERN_REGEX.formatted("WFLY"))));
@@ -62,7 +75,7 @@ public class PRDependabotTest {
     }
 
     @Test
-    void testDependabotPREmptyBody() throws Throwable {
+    void testDependabotFormatCheckSkipOnPROpened() throws Throwable {
         wildflyConfigFile = """
                 wildfly:
                       format:
@@ -74,7 +87,8 @@ public class PRDependabotTest {
         pullRequestJson = TestModel.setPullRequestJsonBuilder(pullRequestJsonBuilder -> pullRequestJsonBuilder
                 .userLogin(RuntimeConstants.DEPENDABOT)
                 .title("Bump some version from x.y to x.y+1")
-                .description(null));
+                .description("Very detailed description of this upgrade.")
+                .action(Action.OPENED));
 
         TestModel.given(mocks -> WildflyGitHubBotTesting.mockRepo(mocks, wildflyConfigFile, pullRequestJson))
                 .pullRequestEvent(pullRequestJson)
@@ -82,13 +96,8 @@ public class PRDependabotTest {
                     GHPullRequest mockedPR = mocks.pullRequest(pullRequestJson.id());
                     Mockito.verify(mockedPR).comment("WildFly Bot recognized this PR as dependabot dependency update. " +
                             "Please create a WFLY issue and add new comment containing this JIRA link please.");
-                    GHRepository repo = mocks.repository(TestConstants.TEST_REPO);
-                    WildflyGitHubBotTesting.verifyFormatFailure(repo, pullRequestJson, "description, title");
-                    WildflyGitHubBotTesting.verifyFailedFormatComment(mocks, pullRequestJson, String.format("""
-                            - Invalid description content
-
-                            - %s""", String.format(RuntimeConstants.DEFAULT_TITLE_MESSAGE,
-                            PROJECT_PATTERN_REGEX.formatted("WFLY"))));
+                    Assertions.assertTrue(inMemoryLogHandler.getRecords().stream().anyMatch(logRecord -> logRecord
+                            .getMessage().contains("Skipping format check on newly opened dependabot PRs.")));
                 });
     }
 }

--- a/src/test/java/org/wildfly/bot/webhooks/PRDescriptionCheckTest.java
+++ b/src/test/java/org/wildfly/bot/webhooks/PRDescriptionCheckTest.java
@@ -284,4 +284,27 @@ public class PRDescriptionCheckTest {
                     Mockito.verify(repo, never()).createCommitStatus(anyString(), any(), anyString(), anyString(), anyString());
                 });
     }
+
+    @Test
+    void testPREmptyBody() throws Throwable {
+        wildflyConfigFile = """
+                wildfly:
+                  format:
+                    description:
+                      regexes:
+                        - pattern: "https://issues.redhat.com/browse/WFLY-\\\\d+"
+                """;
+
+        pullRequestJson = TestModel.setPullRequestJsonBuilder(pullRequestJsonBuilder -> pullRequestJsonBuilder
+                .description(null));
+
+        TestModel.given(mocks -> WildflyGitHubBotTesting.mockRepo(mocks, wildflyConfigFile, pullRequestJson))
+                .pullRequestEvent(pullRequestJson)
+                .then(mocks -> {
+                    GHRepository repo = mocks.repository(TestConstants.TEST_REPO);
+                    WildflyGitHubBotTesting.verifyFormatFailure(repo, pullRequestJson, "description");
+                    WildflyGitHubBotTesting.verifyFailedFormatComment(mocks, pullRequestJson,
+                            "- Invalid description content");
+                });
+    }
 }


### PR DESCRIPTION
Format is checked only after dependabot PR is edited. Also edited tests so it tests PR opened and edited scenarios.
resolves #219 